### PR TITLE
Update to v6.9.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
-cmake -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
+cmake --log-level STATUS -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,17 @@
 
 set -ex
 
-cmake -S"${SRC_DIR}/${PKG_NAME}" -Bbuild -GNinja ${CMAKE_ARGS} \
+# OpenGL support
+if [[ "${target_platform}" == osx-* ]]; then
+  CMAKE_ARGS="
+    ${CMAKE_ARGS}
+    -DQT_FORCE_WARN_APPLE_SDK_AND_XCODE_CHECK=ON
+    -DQT_APPLE_SDK_PATH=${CONDA_BUILD_SYSROOT}
+    -DQT_MAC_SDK_VERSION=${OSX_SDK_VER}
+  "
+fi
+
+cmake --log-level STATUS -S"${SRC_DIR}/${PKG_NAME}" -Bbuild -GNinja ${CMAKE_ARGS} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_INSTALL_RPATH=${PREFIX}/lib \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,27 @@
-c_stdlib_version:  # [osx]
-  - 11.3           # [osx]
+# https://doc.qt.io/qt-6/macos.html
+c_stdlib_version:  # [not linux]
+  - 12.0           # [osx]
+  - 2022.12        # [win]
+OSX_SDK_VER:
+  - 13.3
+
+# https://doc.qt.io/qt-6/windows.html
+c_compiler:    # [win]
+  - vs2022     # [win]
+cxx_compiler:  # [win]
+  - vs2022     # [win]
+
+# https://en.wikipedia.org/wiki/Xcode
+c_compiler_version:    # [osx]
+  - 17                 # [osx]
+cxx_compiler_version:  # [osx]
+  - 17                 # [osx]
+
+# Need at least a 12.0 host or else tests will fail.
+extra_labels_for_os:
+  osx-arm64: [ventura]
+
+# Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
+# 11.1 sysroot.
+CONDA_BUILD_SYSROOT:
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "qtsvg" %}
-{% set version = "6.7.3" %}
+{% set version = "6.9.1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  - url: https://download.qt.io/archive/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 40142cb71fb1e07ad612bc361b67f5d54cd9367f9979ae6b86124a064deda06b
+  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+    sha256: 2dfc5de5fd891ff2afd9861e519bf1a26e6deb729b3133f68a28ba763c9abbd5
     folder: {{ name }}
 
 build:
-  number: 1
+  number: 0
   skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -21,14 +21,14 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - pkg-config  # [unix]
-    - bison       # [linux]
-    - flex        # [linux]
-    - gperf       # [linux]
-    - jom         # [win]
-    - m2-bison    # [win]
-    - m2-flex     # [win]
-    - m2-gperf    # [win]
+    - pkg-config     # [unix]
+    - bison          # [linux]
+    - flex           # [linux]
+    - gperf          # [linux]
+    - jom            # [win]
+    - msys2-bison    # [win]
+    - msys2-flex     # [win]
+    - msys2-gperf    # [win]
     - cmake
     - ninja
     - perl


### PR DESCRIPTION
qtsvg 6.9.1

**Destination channel:** defaults

### Links

- [PKG-8685](https://anaconda.atlassian.net/browse/PKG-8685)
- [Upstream repository](https://github.com/qt/qtsvg/tree/v6.9.1)
- [Upstream changelog/diff](https://github.com/qt/qtsvg/compare/v6.7.3...v6.9.1)
- Relevant dependency PRs:
  - AnacondaRecipes/qtbase-feedstock#9

### Explanation of changes:

- Bump version
- Set SDK version on OSX and ignore Qt CMake errors about it not being enough


[PKG-8685]: https://anaconda.atlassian.net/browse/PKG-8685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ