### PR TITLE
qtsvg 6.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtsvg" %}
-{% set version = "6.10.2" %}
+{% set version = "6.11.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: f07ff80f38caf235187200345392ca7479445ddf49a36c3694cd52a735dad6e1
+    sha256: dfa8d653be07087d9407ed4a4ebae847f8953e0b7abd829f089803ab652a30e6
     folder: {{ name }}
 
 build:
@@ -60,7 +60,7 @@ test:
     {% endfor %}
 
 about:
-  home: https://www.qt.io/
+  home: https://www.qt.io
   license: LGPL-3.0-only
   license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
   license_family: LGPL
@@ -68,5 +68,5 @@ about:
   description: |
     Qt helps you create connected devices, UIs & applications that run
     anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
-  doc_url: https://doc.qt.io/
+  doc_url: https://doc.qt.io
   dev_url: https://github.com/qt/{{ name }}


### PR DESCRIPTION
qtsvg 6.11

**Destination channel:** defaults

### Links

- [PKG-11819](https://anaconda.atlassian.net/browse/PKG-11819) 
- [Upstream repository](https://github.com/qt/qtsvg/tree/v6.11.0)

### Explanation of changes:

- version update


[PKG-11819]: https://anaconda.atlassian.net/browse/PKG-11819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ